### PR TITLE
Fix NameError by cimporting `exit` from libc.stdlib

### DIFF
--- a/picoscenes.pyx
+++ b/picoscenes.pyx
@@ -6,7 +6,7 @@ SEEK_END, SEEK_SET, SEEK_CUR)
 from libcpp.memory cimport shared_ptr
 from libc.stdint cimport (uint8_t, uint16_t, uint32_t, uint64_t,
 int8_t, int16_t, int32_t, int64_t)
-from libc.stdlib cimport malloc, realloc, free
+from libc.stdlib cimport malloc, realloc, free, exit
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp.complex cimport complex as ccomplex


### PR DESCRIPTION
Cython module `picoscenes.pyx` uses the `exit()` function to abort on file open failure, but `exit` was not cimported from `libc.stdlib`, leading to a NameError during module initialization.

This commit explicitly cimports `exit`:
    from libc.stdlib cimport malloc, realloc, free, exit

This prevents crashes like the following when importing the module:

    NameError: name 'exit' is not defined

Optionally, future refactoring could replace `exit()` with `raise` for better integration with Python's exception system.